### PR TITLE
Convert text to path in card SVGs to remove font reliance

### DIFF
--- a/Web/public/cards/project_0.svg
+++ b/Web/public/cards/project_0.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="project_0.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="layer18"
+     inkscape:current-layer="layer19"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -442,8 +442,7 @@
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
@@ -460,7 +459,6 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
@@ -479,8 +477,7 @@
            style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
@@ -767,7 +764,6 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
@@ -782,7 +778,6 @@
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
@@ -877,8 +872,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
@@ -892,8 +886,7 @@
          style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
@@ -1003,8 +996,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1014,7 +1006,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
@@ -1196,8 +1187,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
@@ -1207,7 +1197,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
@@ -1266,8 +1255,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1277,7 +1265,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
@@ -1369,8 +1356,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1380,7 +1366,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
@@ -1447,33 +1432,32 @@
       <g
          id="g4452"
          transform="translate(17.072378,139.22293)">
-        <text
-           xml:space="preserve"
+        <g
+           aria-label=" UGS"
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-390.31741"
-           y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             x="-390.31741"
-             y="-19.634789"
-             id="tspan4650"><tspan
-               x="-390.31741"
-               y="-19.634789"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               id="tspan4652"> UGS</tspan></tspan></text>
-        <text
-           sodipodi:linespacing="125%"
-           id="text4249-1-1"
-           y="-19.154787"
-           x="-421.57742"
+           id="text4648">
+          <path
+             d="m -368.94866,-19.154789 c 6.92,0 10.4,-3.92 10.4,-12.72 v -13.8 h -5.96 v 14.48 c 0,4.96 -1.56,6.68 -4.44,6.68 -2.84,0 -4.32,-1.72 -4.32,-6.68 v -14.48 h -6.2 v 13.8 c 0,8.8 3.6,12.72 10.52,12.72 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path6875" />
+          <path
+             d="m -340.94991,-19.154789 c 3.68,0 6.88,-1.4 8.68,-3.16 v -12.16 h -9.68 v 5.08 h 4.16 v 4.2 c -0.56,0.44 -1.56,0.68 -2.48,0.68 -4.84,0 -7.2,-3 -7.2,-8.2 0,-5.04 2.8,-8.08 6.64,-8.08 2.2,0 3.56,0.64 4.84,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -8.32,-3.4 -6.96,0 -12.8,5 -12.8,13.68 0,8.8 5.68,13.32 12.88,13.32 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path6877" />
+          <path
+             d="m -318.92491,-19.154789 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path6879" />
+        </g>
+        <g
+           aria-label="B"
            style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
+           id="text4249-1-1">
+          <path
+             d="m -416.59742,-19.154787 h 13.62 c 8.64,0 15.12,-3.66 15.12,-11.52 0,-5.28 -3.18,-8.34 -7.5,-9.3 v -0.24 c 3.36,-1.2 5.4,-4.8 5.4,-8.52 0,-7.2 -5.94,-9.66 -14.04,-9.66 h -12.6 z m 7.14,-23.1 v -10.56 h 4.98 c 5.04,0 7.56,1.38 7.56,5.1 0,3.36 -2.34,5.46 -7.68,5.46 z m 0,17.52 v -12.18 h 5.76 c 5.76,0 8.82,1.8 8.82,5.82 0,4.38 -3.12,6.36 -8.82,6.36 z"
              style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="-19.154787"
-             x="-421.57742"
-             id="tspan4251-7-36"
-             sodipodi:role="line">B</tspan></text>
+             id="path6882" />
+        </g>
       </g>
     </g>
     <g
@@ -1572,8 +1556,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
@@ -1587,8 +1570,7 @@
          style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
@@ -1760,8 +1742,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1771,7 +1752,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"

--- a/Web/public/cards/project_1.svg
+++ b/Web/public/cards/project_1.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="project_1.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
      inkscape:current-layer="layer16"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -439,15 +439,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -460,32 +460,31 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
              id="tspan4590"
              y="-19.634789"
              x="-387.85742"
-             sodipodi:role="line"><tspan
+             sodipodi:role="line"
+             style="font-size:40px;line-height:1.25"><tspan
                id="tspan4592"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                y="-19.634789"
                x="-387.85742"> RODUCT OWNER</tspan></tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
              y="-19.154787"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
       </g>
     </g>
     <g
@@ -767,28 +766,27 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
                  id="tspan4596"
                  y="-19.634789"
                  x="-390.85742"
-                 sodipodi:role="line"><tspan
+                 sodipodi:role="line"
+                 style="font-size:40px;line-height:1.25"><tspan
                    id="tspan4598"
                    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
                  y="-19.154787"
                  x="-421.57742"
                  id="tspan4251"
@@ -874,31 +872,30 @@
        transform="matrix(0.91,0,0,1.68,504.09742,130.96231)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
-           id="tspan4620"><tspan
+           id="tspan4620"
+           style="font-size:40px;line-height:1.25"><tspan
              x="-390.31741"
              y="-19.634789"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4622">ESTER</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
            y="-19.154787"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
     </g>
     <g
        id="g5692"
@@ -1000,36 +997,35 @@
          transform="translate(271.81319,-20.771358)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4626"><tspan
+             id="tspan4626"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-0"
              sodipodi:role="line">S</tspan><tspan
              id="tspan4330"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="55.845215"
              x="-421.57742"
-             sodipodi:role="line" /></text>
+             sodipodi:role="line"> </tspan></text>
       </g>
     </g>
     <g
@@ -1193,27 +1189,26 @@
          transform="translate(467.07238,-79.22945)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
-             id="tspan4632"><tspan
+             id="tspan4632"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-389.89743"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-4"
@@ -1261,33 +1256,64 @@
       <g
          id="g4389"
          transform="translate(54.827478,82.675308)">
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-390.31741"
-           y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             x="-390.31741"
-             y="-19.634789"
-             id="tspan4638"><tspan
-               x="-390.31741"
-               y="-19.634789"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
-        <text
-           sodipodi:linespacing="125%"
-           id="text4249-1-4"
-           y="-19.154787"
-           x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="-19.154787"
-             x="-421.57742"
-             id="tspan4251-7-7"
-             sodipodi:role="line">R</tspan></text>
+        <g
+           aria-label=" EQUIREMENTS"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4636">
+          <path
+             d="m -379.34866,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8343" />
+          <path
+             d="m -346.59741,-24.234789 c -3.4,0 -5.56,-3.12 -5.56,-8.52 0,-5.08 2.16,-8.04 5.56,-8.04 3.44,0 5.56,2.96 5.56,8.04 0,5.4 -2.12,8.52 -5.56,8.52 z m 8.68,11.96 c 2.08,0 3.72,-0.4 4.72,-0.92 l -1.08,-4.44 c -0.8,0.24 -1.8,0.4 -2.92,0.4 -2.16,0 -4.48,-0.64 -5.68,-2.44 5,-1.52 8.2,-6.16 8.2,-13.08 0,-8.52 -4.84,-13.4 -11.92,-13.4 -7.08,0 -11.92,4.84 -11.92,13.4 0,7.32 3.6,12.12 9.08,13.32 1.92,4.16 5.84,7.16 11.52,7.16 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8345" />
+          <path
+             d="m -319.41741,-19.154789 c 6.92,0 10.4,-3.92 10.4,-12.72 v -13.8 h -5.96 v 14.48 c 0,4.96 -1.56,6.68 -4.44,6.68 -2.84,0 -4.32,-1.72 -4.32,-6.68 v -14.48 h -6.2 v 13.8 c 0,8.8 3.6,12.72 10.52,12.72 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8347" />
+          <path
+             d="m -303.09866,-19.634789 h 6.24 v -26.04 h -6.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8349" />
+          <path
+             d="m -290.83304,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8351" />
+          <path
+             d="m -266.14554,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8353" />
+          <path
+             d="m -244.11429,-19.634789 h 5.6 v -9.04 c 0,-2.56 -0.52,-7 -0.84,-9.56 h 0.16 l 2.08,6.8 3.48,9.6 h 3.52 l 3.52,-9.6 2.16,-6.8 h 0.16 c -0.32,2.56 -0.84,7 -0.84,9.56 v 9.04 h 5.64 v -26.04 h -6.8 l -3.96,11.32 c -0.52,1.52 -0.92,3.08 -1.4,4.72 h -0.16 c -0.48,-1.64 -0.92,-3.2 -1.4,-4.72 l -4.12,-11.32 h -6.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8355" />
+          <path
+             d="m -213.48929,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8357" />
+          <path
+             d="m -191.45804,-19.634789 h 5.92 v -8.76 c 0,-3.12 -0.48,-6.72 -0.8,-9.6 h 0.16 c 0.8,2.04 1.64,4.12 2.52,5.88 l 6.44,12.48 h 6.4 v -26.04 h -5.88 v 8.76 c 0,3.08 0.48,6.8 0.8,9.6 h -0.16 c -0.8,-2.04 -1.64,-4.12 -2.56,-5.88 l -6.4,-12.48 h -6.44 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8359" />
+          <path
+             d="m -159.65929,-19.634789 h 6.2 v -20.84 h 7.08 v -5.2 h -20.36 v 5.2 h 7.08 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8361" />
+          <path
+             d="m -135.25304,-19.154789 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path8363" />
+        </g>
+        <g
+           aria-label="R"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4249-1-4">
+          <path
+             d="m -416.59742,-19.154787 h 7.14 v -15.24 h 5.82 l 8.4,15.24 h 7.98 l -9.3,-16.32 c 4.68,-1.62 7.74,-5.28 7.74,-11.22 0,-8.82 -6.3,-11.7 -14.52,-11.7 h -13.26 z m 7.14,-20.94 v -12.6 h 5.4 c 5.34,0 8.22,1.56 8.22,6 0,4.38 -2.88,6.6 -8.22,6.6 z"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             id="path8366" />
+        </g>
       </g>
     </g>
     <g
@@ -1366,27 +1392,26 @@
          transform="translate(1.7662494,107.08007)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4644"><tspan
+             id="tspan4644"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-3"
@@ -1449,27 +1474,26 @@
          transform="translate(17.072378,139.22293)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4650"><tspan
+             id="tspan4650"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-36"
@@ -1569,31 +1593,30 @@
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
-           id="tspan4656"><tspan
+           id="tspan4656"
+           style="font-size:40px;line-height:1.25"><tspan
              x="285.9982"
              y="130.30241"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4658">ROCESS</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
            y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
     </g>
     <g
        id="g6989"
@@ -1757,27 +1780,26 @@
          transform="translate(1016.1107,-30.890409)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4662"><tspan
+             id="tspan4662"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-00"

--- a/Web/public/cards/project_2.svg
+++ b/Web/public/cards/project_2.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="project_2.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
      inkscape:current-layer="layer20"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -442,8 +442,7 @@
        style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
@@ -460,7 +459,6 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
@@ -479,8 +477,7 @@
            style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
@@ -767,7 +764,6 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
@@ -782,7 +778,6 @@
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
@@ -877,8 +872,7 @@
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
@@ -892,8 +886,7 @@
          style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
@@ -1003,8 +996,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1014,7 +1006,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
@@ -1196,8 +1187,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
@@ -1207,7 +1197,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
@@ -1266,8 +1255,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1277,7 +1265,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
@@ -1369,8 +1356,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1380,7 +1366,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
@@ -1452,8 +1437,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1463,7 +1447,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
@@ -1567,33 +1550,44 @@
        style="display:inline"
        id="g4253-7-4"
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
-      <text
-         xml:space="preserve"
+      <g
+         aria-label="ROCESS"
          style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="285.9982"
-         y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           x="285.9982"
-           y="130.30241"
-           id="tspan4656"><tspan
-             x="285.9982"
-             y="130.30241"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-             id="tspan4658">ROCESS</tspan></tspan></text>
-      <text
-         xml:space="preserve"
+         id="text4654">
+        <path
+           d="m 288.9982,130.30241 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path9843" />
+        <path
+           d="m 324.4057,130.78241 c 7.08,0 11.92,-5.08 11.92,-13.6 0,-8.52 -4.84,-13.4 -11.92,-13.4 -7.08,0 -11.92,4.84 -11.92,13.4 0,8.52 4.84,13.6 11.92,13.6 z m 0,-5.36 c -3.4,0 -5.56,-3.2 -5.56,-8.24 0,-5.08 2.16,-8.04 5.56,-8.04 3.44,0 5.56,2.96 5.56,8.04 0,5.04 -2.12,8.24 -5.56,8.24 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path9845" />
+        <path
+           d="m 352.2257,130.78241 c 3.28,0 6.16,-1.24 8.44,-3.84 l -3.24,-3.68 c -1.24,1.32 -2.88,2.16 -5,2.16 -3.64,0 -6.08,-3 -6.08,-8.2 0,-5.04 2.76,-8.08 6.2,-8.08 1.84,0 3.2,0.6 4.48,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -7.92,-3.4 -6.56,0 -12.4,5 -12.4,13.68 0,8.8 5.6,13.32 12.24,13.32 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path9847" />
+        <path
+           d="m 364.54507,130.30241 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path9849" />
+        <path
+           d="m 394.65632,130.78241 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path9851" />
+        <path
+           d="m 416.21882,130.78241 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path9853" />
+      </g>
+      <g
+         aria-label="P"
          style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="254.7382"
-         y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           id="tspan4251-7-9"
-           x="254.7382"
-           y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+         id="text4249-1-0">
+        <path
+           d="m 259.7182,130.78242 h 7.14 v -14.34 h 5.52 c 8.46,0 15,-3.96 15,-12.72 0,-9.119995 -6.54,-12.179995 -15.24,-12.179995 h -12.42 z m 7.14,-20.04 V 97.242425 h 4.74 c 5.7,0 8.7,1.68 8.7,6.479995 0,4.74 -2.7,7.02 -8.46,7.02 z"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+           id="path9856" />
+      </g>
     </g>
     <g
        id="g6989"
@@ -1760,8 +1754,7 @@
            style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
@@ -1771,7 +1764,6 @@
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"

--- a/Web/public/cards/project_3.svg
+++ b/Web/public/cards/project_3.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.design.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="project_3.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="-59.765198"
+     inkscape:cx="-182.2652"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="layer22"
+     inkscape:current-layer="layer18"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -158,15 +158,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -180,33 +180,40 @@
       <g
          id="g4421"
          transform="translate(1.7662494,107.08007)">
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-390.31741"
-           y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             x="-390.31741"
-             y="-19.634789"
-             id="tspan4644"><tspan
-               x="-390.31741"
-               y="-19.634789"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               id="tspan4646"> ESIGN</tspan></tspan></text>
-        <text
-           sodipodi:linespacing="125%"
-           id="text4249-1-2"
-           y="-19.154787"
-           x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="-19.154787"
-             x="-421.57742"
-             id="tspan4251-7-3"
-             sodipodi:role="line">D</tspan></text>
+        <g
+           aria-label=" ESIGN"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4642">
+          <path
+             d="m -379.34866,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path10519" />
+          <path
+             d="m -349.23741,-19.154789 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path10521" />
+          <path
+             d="m -334.97366,-19.634789 h 6.24 v -26.04 h -6.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path10523" />
+          <path
+             d="m -311.02804,-19.154789 c 3.68,0 6.88,-1.4 8.68,-3.16 v -12.16 h -9.68 v 5.08 h 4.16 v 4.2 c -0.56,0.44 -1.56,0.68 -2.48,0.68 -4.84,0 -7.2,-3 -7.2,-8.2 0,-5.04 2.8,-8.08 6.64,-8.08 2.2,0 3.56,0.64 4.84,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -8.32,-3.4 -6.96,0 -12.8,5 -12.8,13.68 0,8.8 5.68,13.32 12.88,13.32 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path10525" />
+          <path
+             d="m -297.08304,-19.634789 h 5.92 v -8.76 c 0,-3.12 -0.48,-6.72 -0.8,-9.6 h 0.16 c 0.8,2.04 1.64,4.12 2.52,5.88 l 6.44,12.48 h 6.4 v -26.04 h -5.88 v 8.76 c 0,3.08 0.48,6.8 0.8,9.6 h -0.16 c -0.8,-2.04 -1.64,-4.12 -2.56,-5.88 l -6.4,-12.48 h -6.44 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path10527" />
+        </g>
+        <g
+           aria-label="D"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4249-1-2">
+          <path
+             d="m -416.59742,-19.154787 h 10.86 c 11.64,0 18.84,-6.72 18.84,-19.8 0,-13.02 -7.2,-19.44 -19.2,-19.44 h -10.5 z m 7.14,-5.76 v -27.66 h 2.88 c 7.8,0 12.3,4.02 12.3,13.62 0,9.66 -4.5,14.04 -12.3,14.04 z"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             id="path10530" />
+        </g>
       </g>
     </g>
     <g

--- a/Web/public/cards/project_4.svg
+++ b/Web/public/cards/project_4.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="project_4.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="layer20"
+     inkscape:current-layer="layer21"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -439,15 +439,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -460,32 +460,31 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
              id="tspan4590"
              y="-19.634789"
              x="-387.85742"
-             sodipodi:role="line"><tspan
+             sodipodi:role="line"
+             style="font-size:40px;line-height:1.25"><tspan
                id="tspan4592"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                y="-19.634789"
                x="-387.85742"> RODUCT OWNER</tspan></tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
              y="-19.154787"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
       </g>
     </g>
     <g
@@ -767,28 +766,27 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
                  id="tspan4596"
                  y="-19.634789"
                  x="-390.85742"
-                 sodipodi:role="line"><tspan
+                 sodipodi:role="line"
+                 style="font-size:40px;line-height:1.25"><tspan
                    id="tspan4598"
                    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
                  y="-19.154787"
                  x="-421.57742"
                  id="tspan4251"
@@ -874,31 +872,30 @@
        transform="matrix(0.91,0,0,1.68,504.09742,130.96231)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
-           id="tspan4620"><tspan
+           id="tspan4620"
+           style="font-size:40px;line-height:1.25"><tspan
              x="-390.31741"
              y="-19.634789"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4622">ESTER</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
            y="-19.154787"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
     </g>
     <g
        id="g5692"
@@ -1000,36 +997,35 @@
          transform="translate(271.81319,-20.771358)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4626"><tspan
+             id="tspan4626"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-0"
              sodipodi:role="line">S</tspan><tspan
              id="tspan4330"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="55.845215"
              x="-421.57742"
-             sodipodi:role="line" /></text>
+             sodipodi:role="line"> </tspan></text>
       </g>
     </g>
     <g
@@ -1193,27 +1189,26 @@
          transform="translate(467.07238,-79.22945)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
-             id="tspan4632"><tspan
+             id="tspan4632"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-389.89743"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-4"
@@ -1263,27 +1258,26 @@
          transform="translate(54.827478,82.675308)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4638"><tspan
+             id="tspan4638"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-7"
@@ -1366,27 +1360,26 @@
          transform="translate(1.7662494,107.08007)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4644"><tspan
+             id="tspan4644"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-3"
@@ -1449,27 +1442,26 @@
          transform="translate(17.072378,139.22293)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4650"><tspan
+             id="tspan4650"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-36"
@@ -1569,31 +1561,30 @@
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
-           id="tspan4656"><tspan
+           id="tspan4656"
+           style="font-size:40px;line-height:1.25"><tspan
              x="285.9982"
              y="130.30241"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4658">ROCESS</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
            y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
     </g>
     <g
        id="g6989"
@@ -1755,33 +1746,32 @@
       <g
          id="g4498"
          transform="translate(1016.1107,-30.890409)">
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-390.31741"
-           y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             x="-390.31741"
-             y="-19.634789"
-             id="tspan4662"><tspan
-               x="-390.31741"
-               y="-19.634789"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               id="tspan4664">ODE</tspan></tspan></text>
-        <text
-           sodipodi:linespacing="125%"
-           id="text4249-1-12"
-           y="-19.154787"
-           x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="-19.154787"
-             x="-421.57742"
-             id="tspan4251-7-00"
-             sodipodi:role="line">C</tspan></text>
+        <g
+           aria-label="ODE"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4660">
+          <path
+             d="m -376.59741,-19.154789 c 7.08,0 11.92,-5.08 11.92,-13.6 0,-8.52 -4.84,-13.4 -11.92,-13.4 -7.08,0 -11.92,4.84 -11.92,13.4 0,8.52 4.84,13.6 11.92,13.6 z m 0,-5.36 c -3.4,0 -5.56,-3.2 -5.56,-8.24 0,-5.08 2.16,-8.04 5.56,-8.04 3.44,0 5.56,2.96 5.56,8.04 0,5.04 -2.12,8.24 -5.56,8.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path11991" />
+          <path
+             d="m -359.81741,-19.634789 h 7.84 c 7.6,0 12.84,-4.12 12.84,-13.12 0,-9.04 -5.24,-12.92 -13.2,-12.92 h -7.48 z m 6.24,-5 v -16.04 h 0.88 c 4.2,0 7.2,1.72 7.2,7.92 0,6.16 -3,8.12 -7.2,8.12 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path11993" />
+          <path
+             d="m -334.34866,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path11995" />
+        </g>
+        <g
+           aria-label="C"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4249-1-12">
+          <path
+             d="m -400.93742,-18.434787 c 5.04,0 9.12,-1.92 12.42,-5.7 l -3.84,-4.26 c -2.16,2.4 -4.86,3.78 -8.28,3.78 -6.54,0 -10.68,-5.4 -10.68,-14.22 0,-8.76 4.56,-14.04 10.8,-14.04 3.06,0 5.4,1.14 7.44,3.12 l 3.78,-4.38 c -2.46,-2.7 -6.42,-4.98 -11.34,-4.98 -9.96,0 -18,7.62 -18,20.46 0,13.02 7.86,20.22 17.7,20.22 z"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             id="path11998" />
+        </g>
       </g>
     </g>
     <g

--- a/Web/public/cards/team_0.svg
+++ b/Web/public/cards/team_0.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="team_0.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="g4253-7-4"
+     inkscape:current-layer="layer6"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -439,15 +439,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -459,33 +459,64 @@
       <g
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
-        <text
-           sodipodi:linespacing="125%"
-           id="text4588"
-           y="-19.634789"
-           x="-387.85742"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             id="tspan4590"
-             y="-19.634789"
-             x="-387.85742"
-             sodipodi:role="line"><tspan
-               id="tspan4592"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               y="-19.634789"
-               x="-387.85742"> RODUCT OWNER</tspan></tspan></text>
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-411.73743"
-           y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             id="tspan4212"
-             x="-411.73743"
-             y="-19.154787"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+        <g
+           aria-label=" RODUCT OWNER"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4588">
+          <path
+             d="m -376.88867,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13459" />
+          <path
+             d="m -341.48117,-19.154789 c 7.08,0 11.92,-5.08 11.92,-13.6 0,-8.52 -4.84,-13.4 -11.92,-13.4 -7.08,0 -11.92,4.84 -11.92,13.4 0,8.52 4.84,13.6 11.92,13.6 z m 0,-5.36 c -3.4,0 -5.56,-3.2 -5.56,-8.24 0,-5.08 2.16,-8.04 5.56,-8.04 3.44,0 5.56,2.96 5.56,8.04 0,5.04 -2.12,8.24 -5.56,8.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13461" />
+          <path
+             d="m -324.70117,-19.634789 h 7.84 c 7.6,0 12.84,-4.12 12.84,-13.12 0,-9.04 -5.24,-12.92 -13.2,-12.92 h -7.48 z m 6.24,-5 v -16.04 h 0.88 c 4.2,0 7.2,1.72 7.2,7.92 0,6.16 -3,8.12 -7.2,8.12 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13463" />
+          <path
+             d="m -288.83242,-19.154789 c 6.92,0 10.4,-3.92 10.4,-12.72 v -13.8 h -5.96 v 14.48 c 0,4.96 -1.56,6.68 -4.44,6.68 -2.84,0 -4.32,-1.72 -4.32,-6.68 v -14.48 h -6.2 v 13.8 c 0,8.8 3.6,12.72 10.52,12.72 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13465" />
+          <path
+             d="m -261.47367,-19.154789 c 3.28,0 6.16,-1.24 8.44,-3.84 l -3.24,-3.68 c -1.24,1.32 -2.88,2.16 -5,2.16 -3.64,0 -6.08,-3 -6.08,-8.2 0,-5.04 2.76,-8.08 6.2,-8.08 1.84,0 3.2,0.6 4.48,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -7.92,-3.4 -6.56,0 -12.4,5 -12.4,13.68 0,8.8 5.6,13.32 12.24,13.32 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13467" />
+          <path
+             d="m -244.54305,-19.634789 h 6.2 v -20.84 h 7.08 v -5.2 h -20.36 v 5.2 h 7.08 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13469" />
+          <path
+             d="m -208.59055,-19.154789 c 7.08,0 11.92,-5.08 11.92,-13.6 0,-8.52 -4.84,-13.4 -11.92,-13.4 -7.08,0 -11.92,4.84 -11.92,13.4 0,8.52 4.84,13.6 11.92,13.6 z m 0,-5.36 c -3.4,0 -5.56,-3.2 -5.56,-8.24 0,-5.08 2.16,-8.04 5.56,-8.04 3.44,0 5.56,2.96 5.56,8.04 0,5.04 -2.12,8.24 -5.56,8.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13471" />
+          <path
+             d="m -189.61055,-19.634789 h 7.76 l 2.24,-11.4 c 0.44,-2.04 0.72,-4.08 1,-6.16 h 0.16 c 0.24,2.08 0.52,4.12 0.96,6.16 l 2.36,11.4 h 7.88 l 4.6,-26.04 h -5.92 l -1.76,11.92 c -0.32,2.68 -0.68,5.44 -0.96,8.32 h -0.16 c -0.48,-2.88 -1,-5.68 -1.52,-8.32 l -2.64,-11.92 h -5.36 l -2.72,11.92 c -0.52,2.72 -1.04,5.48 -1.52,8.32 h -0.16 c -0.28,-2.84 -0.6,-5.56 -0.96,-8.32 l -1.64,-11.92 h -6.32 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13473" />
+          <path
+             d="m -159.1543,-19.634789 h 5.92 v -8.76 c 0,-3.12 -0.48,-6.72 -0.8,-9.6 h 0.16 c 0.8,2.04 1.64,4.12 2.52,5.88 l 6.44,12.48 h 6.4 v -26.04 h -5.88 v 8.76 c 0,3.08 0.48,6.8 0.8,9.6 h -0.16 c -0.8,-2.04 -1.64,-4.12 -2.56,-5.88 l -6.4,-12.48 h -6.44 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13475" />
+          <path
+             d="m -132.43555,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13477" />
+          <path
+             d="m -110.4043,-19.634789 h 6.24 v -9.16 h 3.04 l 4.800003,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.160003,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.960003,0 4.560003,0.8 4.560003,3.28 0,2.48 -1.6,3.76 -4.560003,3.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path13479" />
+        </g>
+        <g
+           aria-label="P"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4210">
+          <path
+             d="m -406.75743,-19.154787 h 7.14 v -14.34 h 5.52 c 8.46,0 15,-3.96 15,-12.72 0,-9.12 -6.54,-12.18 -15.24,-12.18 h -12.42 z m 7.14,-20.04 v -13.5 h 4.74 c 5.7,0 8.7,1.68 8.7,6.48 0,4.74 -2.7,7.02 -8.46,7.02 z"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             id="path13482" />
+        </g>
       </g>
     </g>
     <g
@@ -767,28 +798,27 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
                  id="tspan4596"
                  y="-19.634789"
                  x="-390.85742"
-                 sodipodi:role="line"><tspan
+                 sodipodi:role="line"
+                 style="font-size:40px;line-height:1.25"><tspan
                    id="tspan4598"
                    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
                  y="-19.154787"
                  x="-421.57742"
                  id="tspan4251"
@@ -874,31 +904,30 @@
        transform="matrix(0.91,0,0,1.68,504.09742,130.96231)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
-           id="tspan4620"><tspan
+           id="tspan4620"
+           style="font-size:40px;line-height:1.25"><tspan
              x="-390.31741"
              y="-19.634789"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4622">ESTER</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
            y="-19.154787"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
     </g>
     <g
        id="g5692"
@@ -1000,36 +1029,35 @@
          transform="translate(271.81319,-20.771358)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4626"><tspan
+             id="tspan4626"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-0"
              sodipodi:role="line">S</tspan><tspan
              id="tspan4330"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="55.845215"
              x="-421.57742"
-             sodipodi:role="line" /></text>
+             sodipodi:role="line"> </tspan></text>
       </g>
     </g>
     <g
@@ -1193,27 +1221,26 @@
          transform="translate(467.07238,-79.22945)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
-             id="tspan4632"><tspan
+             id="tspan4632"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-389.89743"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-4"
@@ -1263,27 +1290,26 @@
          transform="translate(54.827478,82.675308)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4638"><tspan
+             id="tspan4638"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-7"
@@ -1366,27 +1392,26 @@
          transform="translate(1.7662494,107.08007)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4644"><tspan
+             id="tspan4644"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-3"
@@ -1449,27 +1474,26 @@
          transform="translate(17.072378,139.22293)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4650"><tspan
+             id="tspan4650"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-36"
@@ -1569,31 +1593,30 @@
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
-           id="tspan4656"><tspan
+           id="tspan4656"
+           style="font-size:40px;line-height:1.25"><tspan
              x="285.9982"
              y="130.30241"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4658">ROCESS</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
            y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
     </g>
     <g
        id="g6989"
@@ -1757,27 +1780,26 @@
          transform="translate(1016.1107,-30.890409)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4662"><tspan
+             id="tspan4662"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-00"

--- a/Web/public/cards/team_1.svg
+++ b/Web/public/cards/team_1.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="team_1.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="g4253-7-4"
+     inkscape:current-layer="layer12"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -439,15 +439,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -460,32 +460,31 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
              id="tspan4590"
              y="-19.634789"
              x="-387.85742"
-             sodipodi:role="line"><tspan
+             sodipodi:role="line"
+             style="font-size:40px;line-height:1.25"><tspan
                id="tspan4592"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                y="-19.634789"
                x="-387.85742"> RODUCT OWNER</tspan></tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
              y="-19.154787"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
       </g>
     </g>
     <g
@@ -767,28 +766,27 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
                  id="tspan4596"
                  y="-19.634789"
                  x="-390.85742"
-                 sodipodi:role="line"><tspan
+                 sodipodi:role="line"
+                 style="font-size:40px;line-height:1.25"><tspan
                    id="tspan4598"
                    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
                  y="-19.154787"
                  x="-421.57742"
                  id="tspan4251"
@@ -874,31 +872,30 @@
        transform="matrix(0.91,0,0,1.68,504.09742,130.96231)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
-           id="tspan4620"><tspan
+           id="tspan4620"
+           style="font-size:40px;line-height:1.25"><tspan
              x="-390.31741"
              y="-19.634789"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4622">ESTER</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
            y="-19.154787"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
     </g>
     <g
        id="g5692"
@@ -998,38 +995,61 @@
       <g
          id="g4332"
          transform="translate(271.81319,-20.771358)">
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-390.31741"
-           y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             x="-390.31741"
-             y="-19.634789"
-             id="tspan4626"><tspan
-               x="-390.31741"
-               y="-19.634789"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               id="tspan4628">CRUM MASTER</tspan></tspan></text>
-        <text
-           sodipodi:linespacing="125%"
-           id="text4249-1-9"
-           y="-19.154787"
-           x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="-19.154787"
-             x="-421.57742"
-             id="tspan4251-7-0"
-             sodipodi:role="line">S</tspan><tspan
-             id="tspan4330"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="55.845215"
-             x="-421.57742"
-             sodipodi:role="line" /></text>
+        <g
+           aria-label="CRUM MASTER"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4624">
+          <path
+             d="m -376.27741,-19.154789 c 3.28,0 6.16,-1.24 8.44,-3.84 l -3.24,-3.68 c -1.24,1.32 -2.88,2.16 -5,2.16 -3.64,0 -6.08,-3 -6.08,-8.2 0,-5.04 2.76,-8.08 6.2,-8.08 1.84,0 3.2,0.6 4.48,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -7.92,-3.4 -6.56,0 -12.4,5 -12.4,13.68 0,8.8 5.6,13.32 12.24,13.32 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14943" />
+          <path
+             d="m -363.95804,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14945" />
+          <path
+             d="m -328.87054,-19.154789 c 6.92,0 10.4,-3.92 10.4,-12.72 v -13.8 h -5.96 v 14.48 c 0,4.96 -1.56,6.68 -4.44,6.68 -2.84,0 -4.32,-1.72 -4.32,-6.68 v -14.48 h -6.2 v 13.8 c 0,8.8 3.6,12.72 10.52,12.72 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14947" />
+          <path
+             d="m -312.55179,-19.634789 h 5.6 v -9.04 c 0,-2.56 -0.52,-7 -0.84,-9.56 h 0.16 l 2.08,6.8 3.48,9.6 h 3.52 l 3.52,-9.6 2.16,-6.8 h 0.16 c -0.32,2.56 -0.84,7 -0.84,9.56 v 9.04 h 5.64 v -26.04 h -6.8 l -3.96,11.32 c -0.52,1.52 -0.92,3.08 -1.4,4.72 h -0.16 c -0.48,-1.64 -0.92,-3.2 -1.4,-4.72 l -4.12,-11.32 h -6.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14949" />
+          <path
+             d="m -273.95804,-19.634789 h 5.6 v -9.04 c 0,-2.56 -0.52,-7 -0.84,-9.56 h 0.16 l 2.08,6.8 3.48,9.6 h 3.52 l 3.52,-9.6 2.16,-6.8 h 0.16 c -0.32,2.56 -0.84,7 -0.84,9.56 v 9.04 h 5.64 v -26.04 h -6.8 l -3.96,11.32 c -0.52,1.52 -0.92,3.08 -1.4,4.72 h -0.16 c -0.48,-1.64 -0.92,-3.2 -1.4,-4.72 l -4.12,-11.32 h -6.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14951" />
+          <path
+             d="m -237.01304,-32.674789 c 0.68,-2.56 1.36,-5.64 2,-8.36 h 0.16 c 0.68,2.72 1.36,5.8 2.04,8.36 l 0.56,2.24 h -5.32 z m -9.64,13.04 h 6.36 l 1.52,-6 h 7.72 l 1.52,6 h 6.56 l -8.12,-26.04 h -7.44 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14953" />
+          <path
+             d="m -212.20616,-19.154789 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14955" />
+          <path
+             d="m -193.64366,-19.634789 h 6.2 v -20.84 h 7.08 v -5.2 h -20.36 v 5.2 h 7.08 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14957" />
+          <path
+             d="m -176.37991,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14959" />
+          <path
+             d="m -154.34866,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path14961" />
+        </g>
+        <g
+           aria-label="S
+ "
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4249-1-9">
+          <path
+             d="m -405.13742,-18.434787 c 8.88,0 14.16,-5.34 14.16,-11.7 0,-5.7 -3.24,-8.64 -7.92,-10.62 l -5.28,-2.16 c -3.24,-1.38 -6.18,-2.46 -6.18,-5.46 0,-2.82 2.34,-4.5 6,-4.5 3,0 5.88,1.2 8.34,3.3 l 3.84,-4.68 c -3.06,-2.94 -7.44,-4.86 -12.18,-4.86 -7.68,0 -13.2,4.86 -13.2,11.16 0,5.7 4.02,8.76 7.92,10.38 l 5.34,2.34 c 3.54,1.5 6.06,2.52 6.06,5.64 0,3 -2.4,4.98 -6.72,4.98 -3.78,0 -7.68,-1.56 -10.5,-4.26 l -3.84,4.68 c 3.72,3.78 8.76,5.76 14.16,5.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             id="path14964" />
+        </g>
       </g>
     </g>
     <g
@@ -1193,27 +1213,26 @@
          transform="translate(467.07238,-79.22945)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
-             id="tspan4632"><tspan
+             id="tspan4632"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-389.89743"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-4"
@@ -1263,27 +1282,26 @@
          transform="translate(54.827478,82.675308)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4638"><tspan
+             id="tspan4638"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-7"
@@ -1366,27 +1384,26 @@
          transform="translate(1.7662494,107.08007)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4644"><tspan
+             id="tspan4644"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-3"
@@ -1449,27 +1466,26 @@
          transform="translate(17.072378,139.22293)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4650"><tspan
+             id="tspan4650"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-36"
@@ -1569,31 +1585,30 @@
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
-           id="tspan4656"><tspan
+           id="tspan4656"
+           style="font-size:40px;line-height:1.25"><tspan
              x="285.9982"
              y="130.30241"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4658">ROCESS</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
            y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
     </g>
     <g
        id="g6989"
@@ -1757,27 +1772,26 @@
          transform="translate(1016.1107,-30.890409)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4662"><tspan
+             id="tspan4662"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-00"

--- a/Web/public/cards/team_2.svg
+++ b/Web/public/cards/team_2.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.architect.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="team_2.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="-59.765198"
+     inkscape:cx="-182.2652"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="layer22"
+     inkscape:current-layer="g4235"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -158,15 +158,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      style="display:inline"
@@ -185,33 +185,52 @@
           <g
              transform="translate(14.939996,0)"
              id="g4253">
-            <text
-               sodipodi:linespacing="125%"
-               id="text4594"
-               y="-19.634789"
-               x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-               xml:space="preserve"><tspan
-                 id="tspan4596"
-                 y="-19.634789"
-                 x="-390.85742"
-                 sodipodi:role="line"><tspan
-                   id="tspan4598"
-                   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-                   y="-19.634789"
-                   x="-390.85742"> RCHITECT</tspan></tspan></text>
-            <text
-               sodipodi:linespacing="125%"
-               id="text4249"
-               y="-19.154787"
-               x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-               xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-                 y="-19.154787"
-                 x="-421.57742"
-                 id="tspan4251"
-                 sodipodi:role="line">A</tspan></text>
+            <g
+               aria-label=" RCHITECT"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               id="text4594">
+              <path
+                 d="m -379.88867,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15637" />
+              <path
+                 d="m -344.16117,-19.154789 c 3.28,0 6.16,-1.24 8.44,-3.84 l -3.24,-3.68 c -1.24,1.32 -2.88,2.16 -5,2.16 -3.64,0 -6.08,-3 -6.08,-8.2 0,-5.04 2.76,-8.08 6.2,-8.08 1.84,0 3.2,0.6 4.48,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -7.92,-3.4 -6.56,0 -12.4,5 -12.4,13.68 0,8.8 5.6,13.32 12.24,13.32 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15639" />
+              <path
+                 d="m -331.8418,-19.634789 h 6.24 v -10.72 h 8.6 v 10.72 h 6.2 v -26.04 h -6.2 v 9.92 h -8.6 v -9.92 h -6.24 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15641" />
+              <path
+                 d="m -304.81055,-19.634789 h 6.24 v -26.04 h -6.24 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15643" />
+              <path
+                 d="m -287.46492,-19.634789 h 6.2 v -20.84 h 7.08 v -5.2 h -20.36 v 5.2 h 7.08 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15645" />
+              <path
+                 d="m -270.20117,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15647" />
+              <path
+                 d="m -237.12992,-19.154789 c 3.28,0 6.16,-1.24 8.44,-3.84 l -3.24,-3.68 c -1.24,1.32 -2.88,2.16 -5,2.16 -3.64,0 -6.08,-3 -6.08,-8.2 0,-5.04 2.76,-8.08 6.2,-8.08 1.84,0 3.2,0.6 4.48,1.8 l 3.28,-3.76 c -1.8,-1.88 -4.52,-3.4 -7.92,-3.4 -6.56,0 -12.4,5 -12.4,13.68 0,8.8 5.6,13.32 12.24,13.32 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15649" />
+              <path
+                 d="m -220.1993,-19.634789 h 6.2 v -20.84 h 7.08 v -5.2 h -20.36 v 5.2 h 7.08 z"
+                 style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+                 id="path15651" />
+            </g>
+            <g
+               aria-label="A"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               id="text4249">
+              <path
+                 d="m -408.49742,-39.914787 c 1.26,-4.14 2.4,-8.58 3.42,-12.9 h 0.24 c 1.14,4.26 2.28,8.76 3.54,12.9 l 1.32,4.68 h -9.84 z m -13.2,20.76 h 7.26 l 3,-10.5 h 13.02 l 3,10.5 h 7.56 l -12.72,-39.24 h -8.4 z"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 id="path15654" />
+            </g>
           </g>
         </g>
       </g>

--- a/Web/public/cards/team_3.svg
+++ b/Web/public/cards/team_3.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="team_3.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="g4253-7-4"
+     inkscape:current-layer="layer14"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -439,15 +439,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -460,32 +460,31 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
              id="tspan4590"
              y="-19.634789"
              x="-387.85742"
-             sodipodi:role="line"><tspan
+             sodipodi:role="line"
+             style="font-size:40px;line-height:1.25"><tspan
                id="tspan4592"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                y="-19.634789"
                x="-387.85742"> RODUCT OWNER</tspan></tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
              y="-19.154787"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
       </g>
     </g>
     <g
@@ -767,28 +766,27 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
                  id="tspan4596"
                  y="-19.634789"
                  x="-390.85742"
-                 sodipodi:role="line"><tspan
+                 sodipodi:role="line"
+                 style="font-size:40px;line-height:1.25"><tspan
                    id="tspan4598"
                    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
                  y="-19.154787"
                  x="-421.57742"
                  id="tspan4251"
@@ -874,31 +872,30 @@
        transform="matrix(0.91,0,0,1.68,504.09742,130.96231)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-390.31741"
          y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
+         id="text4618"><tspan
            sodipodi:role="line"
            x="-390.31741"
            y="-19.634789"
-           id="tspan4620"><tspan
+           id="tspan4620"
+           style="font-size:40px;line-height:1.25"><tspan
              x="-390.31741"
              y="-19.634789"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4622">ESTER</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="-421.57742"
          y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1"><tspan
            sodipodi:role="line"
            id="tspan4251-7"
            x="-421.57742"
            y="-19.154787"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
     </g>
     <g
        id="g5692"
@@ -1000,36 +997,35 @@
          transform="translate(271.81319,-20.771358)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4626"><tspan
+             id="tspan4626"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-0"
              sodipodi:role="line">S</tspan><tspan
              id="tspan4330"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="55.845215"
              x="-421.57742"
-             sodipodi:role="line" /></text>
+             sodipodi:role="line"> </tspan></text>
       </g>
     </g>
     <g
@@ -1191,33 +1187,52 @@
       <g
          id="g4361"
          transform="translate(467.07238,-79.22945)">
-        <text
-           xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           x="-389.89743"
-           y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
-             sodipodi:role="line"
-             x="-389.89743"
-             y="-19.634789"
-             id="tspan4632"><tspan
-               x="-389.89743"
-               y="-19.634789"
-               style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-               id="tspan4634"> EVELOPER</tspan></tspan></text>
-        <text
-           sodipodi:linespacing="125%"
-           id="text4249-1-7"
-           y="-19.154787"
-           x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
-             y="-19.154787"
-             x="-421.57742"
-             id="tspan4251-7-4"
-             sodipodi:role="line">D</tspan></text>
+        <g
+           aria-label=" EVELOPER"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4630">
+          <path
+             d="m -378.92868,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17115" />
+          <path
+             d="m -352.57743,-19.634789 h 7.48 l 7.96,-26.04 h -6.32 l -3.12,11.88 c -0.72,2.84 -1.28,5.48 -2.04,8.32 h -0.16 c -0.76,-2.84 -1.32,-5.48 -2.04,-8.32 l -2.84,-11.88 h -6.56 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17117" />
+          <path
+             d="m -334.47556,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17119" />
+          <path
+             d="m -312.44431,-19.634789 h 16.36 v -5.2 h -10.12 v -20.84 h -6.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17121" />
+          <path
+             d="m -282.34931,-19.154789 c 7.08,0 11.92,-5.08 11.92,-13.6 0,-8.52 -4.84,-13.4 -11.92,-13.4 -7.08,0 -11.92,4.84 -11.92,13.4 0,8.52 4.84,13.6 11.92,13.6 z m 0,-5.36 c -3.4,0 -5.56,-3.2 -5.56,-8.24 0,-5.08 2.16,-8.04 5.56,-8.04 3.44,0 5.56,2.96 5.56,8.04 0,5.04 -2.12,8.24 -5.56,8.24 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17123" />
+          <path
+             d="m -265.56931,-19.634789 h 6.24 v -8.64 h 3.08 c 5.48,0 10.24,-2.72 10.24,-8.96 0,-6.4 -4.68,-8.44 -10.4,-8.44 h -9.16 z m 6.24,-13.56 v -7.56 h 2.56 c 3.04,0 4.68,0.92 4.68,3.52 0,2.6 -1.44,4.04 -4.52,4.04 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17125" />
+          <path
+             d="m -241.58493,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17127" />
+          <path
+             d="m -219.55368,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+             id="path17129" />
+        </g>
+        <g
+           aria-label="D"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="text4249-1-7">
+          <path
+             d="m -416.59742,-19.154787 h 10.86 c 11.64,0 18.84,-6.72 18.84,-19.8 0,-13.02 -7.2,-19.44 -19.2,-19.44 h -10.5 z m 7.14,-5.76 v -27.66 h 2.88 c 7.8,0 12.3,4.02 12.3,13.62 0,9.66 -4.5,14.04 -12.3,14.04 z"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             id="path17132" />
+        </g>
       </g>
     </g>
     <g
@@ -1263,27 +1278,26 @@
          transform="translate(54.827478,82.675308)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4638"><tspan
+             id="tspan4638"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-7"
@@ -1366,27 +1380,26 @@
          transform="translate(1.7662494,107.08007)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4644"><tspan
+             id="tspan4644"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-3"
@@ -1449,27 +1462,26 @@
          transform="translate(17.072378,139.22293)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4650"><tspan
+             id="tspan4650"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-36"
@@ -1569,31 +1581,30 @@
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
-           id="tspan4656"><tspan
+           id="tspan4656"
+           style="font-size:40px;line-height:1.25"><tspan
              x="285.9982"
              y="130.30241"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4658">ROCESS</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
            y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
     </g>
     <g
        id="g6989"
@@ -1757,27 +1768,26 @@
          transform="translate(1016.1107,-30.890409)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4662"><tspan
+             id="tspan4662"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-00"

--- a/Web/public/cards/team_4.svg
+++ b/Web/public/cards/team_4.svg
@@ -15,8 +15,8 @@
    viewBox="0 0 372.04722 524.40944"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="mb_neocard_simplified.workarea.svg">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="team_4.svg">
   <defs
      id="defs4">
     <linearGradient
@@ -36,16 +36,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="187.37766"
+     inkscape:cx="64.87766"
      inkscape:cy="255.5707"
      inkscape:document-units="px"
-     inkscape:current-layer="g4253-7-4"
+     inkscape:current-layer="layer9"
      showgrid="false"
      inkscape:snap-object-midpoints="true"
-     inkscape:window-width="2495"
-     inkscape:window-height="1416"
-     inkscape:window-x="65"
-     inkscape:window-y="24"
+     inkscape:window-width="1853"
+     inkscape:window-height="1025"
+     inkscape:window-x="67"
+     inkscape:window-y="27"
      inkscape:window-maximized="1"
      fit-margin-top="0"
      fit-margin-left="0"
@@ -67,7 +67,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -439,15 +439,15 @@
     </g>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        x="-309.10669"
        y="23.878862"
-       id="text4218"
-       sodipodi:linespacing="125%"><tspan
+       id="text4218"><tspan
          sodipodi:role="line"
          id="tspan4220"
          x="-309.10669"
-         y="23.878862" /></text>
+         y="23.878862"
+         style="font-size:40px;line-height:1.25"> </tspan></text>
   </g>
   <g
      inkscape:groupmode="layer"
@@ -460,32 +460,31 @@
          id="g4224"
          transform="matrix(0.91,0,0,1.68,412.09444,130.96231)">
         <text
-           sodipodi:linespacing="125%"
            id="text4588"
            y="-19.634789"
            x="-387.85742"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
              id="tspan4590"
              y="-19.634789"
              x="-387.85742"
-             sodipodi:role="line"><tspan
+             sodipodi:role="line"
+             style="font-size:40px;line-height:1.25"><tspan
                id="tspan4592"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                y="-19.634789"
                x="-387.85742"> RODUCT OWNER</tspan></tspan></text>
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-411.73743"
            y="-19.154787"
-           id="text4210"
-           sodipodi:linespacing="125%"><tspan
+           id="text4210"><tspan
              sodipodi:role="line"
              id="tspan4212"
              x="-411.73743"
              y="-19.154787"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
       </g>
     </g>
     <g
@@ -767,28 +766,27 @@
              transform="translate(14.939996,0)"
              id="g4253">
             <text
-               sodipodi:linespacing="125%"
                id="text4594"
                y="-19.634789"
                x="-390.85742"
-               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
                  id="tspan4596"
                  y="-19.634789"
                  x="-390.85742"
-                 sodipodi:role="line"><tspan
+                 sodipodi:role="line"
+                 style="font-size:40px;line-height:1.25"><tspan
                    id="tspan4598"
                    style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                    y="-19.634789"
                    x="-390.85742"> RCHITECT</tspan></tspan></text>
             <text
-               sodipodi:linespacing="125%"
                id="text4249"
                y="-19.154787"
                x="-421.57742"
-               style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+               style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
                xml:space="preserve"><tspan
-                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+                 style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
                  y="-19.154787"
                  x="-421.57742"
                  id="tspan4251"
@@ -872,33 +870,40 @@
        style="display:inline"
        id="g4253-7"
        transform="matrix(0.91,0,0,1.68,504.09742,130.96231)">
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="-390.31741"
-         y="-19.634789"
-         id="text4618"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           x="-390.31741"
-           y="-19.634789"
-           id="tspan4620"><tspan
-             x="-390.31741"
-             y="-19.634789"
-             style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
-             id="tspan4622">ESTER</tspan></tspan></text>
-      <text
-         xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         x="-421.57742"
-         y="-19.154787"
-         id="text4249-1"
-         sodipodi:linespacing="125%"><tspan
-           sodipodi:role="line"
-           id="tspan4251-7"
-           x="-421.57742"
-           y="-19.154787"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">T</tspan></text>
+      <g
+         aria-label="ESTER"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4618">
+        <path
+           d="m -387.31741,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path18593" />
+        <path
+           d="m -357.20616,-19.154789 c 6.28,0 9.92,-3.8 9.92,-8.16 0,-3.64 -1.92,-5.8 -5.16,-7.08 l -3.24,-1.32 c -2.32,-0.92 -3.96,-1.44 -3.96,-2.96 0,-1.36 1.24,-2.12 3.16,-2.12 1.64,0 3.44,0.68 5.2,1.92 l 3.24,-4.04 c -2.24,-2.08 -5.32,-3.24 -8.44,-3.24 -5.52,0 -9.44,3.52 -9.44,7.88 0,3.76 2.52,6.04 5.28,7.12 l 3.32,1.44 c 2.28,0.92 3.68,1.4 3.68,2.92 0,1.4 -1.08,2.28 -3.44,2.28 -2.2,0 -4.72,-0.88 -6.56,-2.48 l -3.28,4.04 c 2.72,2.6 6.2,3.8 9.72,3.8 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path18595" />
+        <path
+           d="m -338.64366,-19.634789 h 6.2 v -20.84 h 7.08 v -5.2 h -20.36 v 5.2 h 7.08 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path18597" />
+        <path
+           d="m -321.37991,-19.634789 h 16.88 v -5.2 h -10.64 v -5.56 h 8.76 v -5.2 h -8.76 v -4.88 h 10.24 v -5.2 h -16.48 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path18599" />
+        <path
+           d="m -299.34866,-19.634789 h 6.24 v -9.16 h 3.04 l 4.8,9.16 h 6.96 l -5.8,-10.32 c 2.68,-1.28 4.48,-3.72 4.48,-7.52 0,-6.28 -4.64,-8.2 -10.16,-8.2 h -9.56 z m 6.24,-14.08 v -7.04 h 2.84 c 2.96,0 4.56,0.8 4.56,3.28 0,2.48 -1.6,3.76 -4.56,3.76 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
+           id="path18601" />
+      </g>
+      <g
+         aria-label="T"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4249-1">
+        <path
+           d="m -408.73742,-19.154787 h 7.14 v -33.24 h 11.28 v -6 h -29.7 v 6 h 11.28 z"
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+           id="path18604" />
+      </g>
     </g>
     <g
        id="g5692"
@@ -1000,36 +1005,35 @@
          transform="translate(271.81319,-20.771358)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4624"
-           sodipodi:linespacing="125%"><tspan
+           id="text4624"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4626"><tspan
+             id="tspan4626"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4628">CRUM MASTER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-9"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-0"
              sodipodi:role="line">S</tspan><tspan
              id="tspan4330"
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="55.845215"
              x="-421.57742"
-             sodipodi:role="line" /></text>
+             sodipodi:role="line"> </tspan></text>
       </g>
     </g>
     <g
@@ -1193,27 +1197,26 @@
          transform="translate(467.07238,-79.22945)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-389.89743"
            y="-19.634789"
-           id="text4630"
-           sodipodi:linespacing="125%"><tspan
+           id="text4630"><tspan
              sodipodi:role="line"
              x="-389.89743"
              y="-19.634789"
-             id="tspan4632"><tspan
+             id="tspan4632"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-389.89743"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4634"> EVELOPER</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-7"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-4"
@@ -1263,27 +1266,26 @@
          transform="translate(54.827478,82.675308)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4636"
-           sodipodi:linespacing="125%"><tspan
+           id="text4636"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4638"><tspan
+             id="tspan4638"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4640"> EQUIREMENTS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-4"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-7"
@@ -1366,27 +1368,26 @@
          transform="translate(1.7662494,107.08007)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4642"
-           sodipodi:linespacing="125%"><tspan
+           id="text4642"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4644"><tspan
+             id="tspan4644"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4646"> ESIGN</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-2"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-3"
@@ -1449,27 +1450,26 @@
          transform="translate(17.072378,139.22293)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4648"
-           sodipodi:linespacing="125%"><tspan
+           id="text4648"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4650"><tspan
+             id="tspan4650"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4652"> UGS</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-1"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-36"
@@ -1569,31 +1569,30 @@
        transform="matrix(0.91,0,0,1.68,-125.7059,-120.9322)">
       <text
          xml:space="preserve"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="285.9982"
          y="130.30241"
-         id="text4654"
-         sodipodi:linespacing="125%"><tspan
+         id="text4654"><tspan
            sodipodi:role="line"
            x="285.9982"
            y="130.30241"
-           id="tspan4656"><tspan
+           id="tspan4656"
+           style="font-size:40px;line-height:1.25"><tspan
              x="285.9982"
              y="130.30241"
              style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
              id="tspan4658">ROCESS</tspan></tspan></text>
       <text
          xml:space="preserve"
-         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
          x="254.7382"
          y="130.78242"
-         id="text4249-1-0"
-         sodipodi:linespacing="125%"><tspan
+         id="text4249-1-0"><tspan
            sodipodi:role="line"
            id="tspan4251-7-9"
            x="254.7382"
            y="130.78242"
-           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
+           style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'">P</tspan></text>
     </g>
     <g
        id="g6989"
@@ -1757,27 +1756,26 @@
          transform="translate(1016.1107,-30.890409)">
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:source-sans;-inkscape-font-specification:source-sans;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-390.31741"
            y="-19.634789"
-           id="text4660"
-           sodipodi:linespacing="125%"><tspan
+           id="text4660"><tspan
              sodipodi:role="line"
              x="-390.31741"
              y="-19.634789"
-             id="tspan4662"><tspan
+             id="tspan4662"
+             style="font-size:40px;line-height:1.25"><tspan
                x="-390.31741"
                y="-19.634789"
                style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Bold'"
                id="tspan4664">ODE</tspan></tspan></text>
         <text
-           sodipodi:linespacing="125%"
            id="text4249-1-12"
            y="-19.154787"
            x="-421.57742"
-           style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
+             style="font-style:normal;font-variant:normal;font-weight:600;font-stretch:normal;font-size:60px;line-height:1.25;font-family:'Source Sans Pro';-inkscape-font-specification:'Source Sans Pro Semi-Bold'"
              y="-19.154787"
              x="-421.57742"
              id="tspan4251-7-00"


### PR DESCRIPTION
If the cards are viewed on a computer that doesn't have
the same font installed that was used in the svg the
text will frequently end up going out of bounds.

To adress the issue, all the card title texts have been
converted to paths instead.

Ticket: NEOGAME-44